### PR TITLE
Fix bulletin utils path

### DIFF
--- a/lib/utils/bulletin_utils.dart
+++ b/lib/utils/bulletin_utils.dart
@@ -2,9 +2,10 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:intl/intl.dart';
 
 // Funkcija za praćenje novih biltena u posljednjih 12 sati
-Future<int> getNewBulletinsCount(String locationName, String username) async {
+Future<int> getNewBulletinsCount(String locationId, String username) async {
   final querySnapshot = await FirebaseFirestore.instance
-      .collection('locations/$locationName/bulletins')
+      .collection('locations/$locationId/bulletin_board')
+      .where('deleted', isEqualTo: false)
       .where('createdAt',
           isGreaterThan: Timestamp.fromDate(
               DateTime.now().subtract(const Duration(hours: 12))))


### PR DESCRIPTION
## Summary
- preimenovan parametar na `locationId`
- filtrirani obrisani bilteni

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7872534c8327bd2a721e00b763c6