### PR TITLE
Use createdAt for post paths

### DIFF
--- a/lib/local/screens/neighborhood_posts_screen.dart
+++ b/lib/local/screens/neighborhood_posts_screen.dart
@@ -144,12 +144,14 @@ class NeighborhoodPostsScreenState extends State<NeighborhoodPostsScreen> {
   /* ------------------------------------------------------------------ */
 
   void _navigateToPostDetail(BuildContext context, Map<String, dynamic> post) {
+    final DateTime createdAt = (post['createdAt'] as Timestamp).toDate();
     _postService.updatePostViews(
       post['postId'],
       post['userId'],
       widget.countryId,
       widget.cityId,
       widget.neighborhood,
+      createdAt,
     );
     Navigator.push(
       context,

--- a/lib/local/screens/post_detail_screen.dart
+++ b/lib/local/screens/post_detail_screen.dart
@@ -58,7 +58,15 @@ class PostDetailScreenState extends State<PostDetailScreen> {
         "postId: $postId, userId: $userId, country: $country, city: $city, neighborhood: $neighborhood, isVideo: $isVideo");
 
     if (postId.isNotEmpty && userId.isNotEmpty) {
-      _postService.updatePostViews(postId, userId, country, city, neighborhood);
+      final DateTime createdAt = (widget.post['createdAt'] as Timestamp).toDate();
+      _postService.updatePostViews(
+        postId,
+        userId,
+        country,
+        city,
+        neighborhood,
+        createdAt,
+      );
     }
 
     if (isVideo) {
@@ -136,9 +144,12 @@ class PostDetailScreenState extends State<PostDetailScreen> {
         return;
       }
 
-      try {
-        final String metricsPath =
-            'local_community/$countryId/cities/$cityId/neighborhoods/$neighborhoodId/metrics_${DateTime.now().year}_${DateTime.now().month.toString().padLeft(2, '0')}/$postId';
+        try {
+          final DateTime createdAt = (widget.post['createdAt'] as Timestamp).toDate();
+          final String year = createdAt.year.toString();
+          final String month = createdAt.month.toString().padLeft(2, '0');
+          final String metricsPath =
+              'local_community/$countryId/cities/$cityId/neighborhoods/$neighborhoodId/metrics_${year}_${month}/$postId';
 
         await FirebaseFirestore.instance.doc(metricsPath).set(
           {
@@ -209,8 +220,11 @@ class PostDetailScreenState extends State<PostDetailScreen> {
         return;
       }
 
-      final String metricsPath =
-          'local_community/$country/cities/$city/neighborhoods/$neighborhood/metrics_${DateTime.now().year}_${DateTime.now().month.toString().padLeft(2, '0')}/$postId';
+        final DateTime createdAt = (widget.post['createdAt'] as Timestamp).toDate();
+        final String year = createdAt.year.toString();
+        final String month = createdAt.month.toString().padLeft(2, '0');
+        final String metricsPath =
+            'local_community/$country/cities/$city/neighborhoods/$neighborhood/metrics_${year}_${month}/$postId';
 
       DocumentSnapshot metricsSnapshot =
           await FirebaseFirestore.instance.doc(metricsPath).get();
@@ -297,10 +311,13 @@ class PostDetailScreenState extends State<PostDetailScreen> {
 
       WriteBatch batch = FirebaseFirestore.instance.batch();
 
-      final String metricsPath =
-          'local_community/$country/cities/$city/neighborhoods/$neighborhood/metrics_${DateTime.now().year}_${DateTime.now().month.toString().padLeft(2, '0')}/$postId';
-      final String postPath =
-          'local_community/$country/cities/$city/neighborhoods/$neighborhood/posts_${DateTime.now().year}_${DateTime.now().month.toString().padLeft(2, '0')}/$postId';
+        final DateTime createdAt = (widget.post['createdAt'] as Timestamp).toDate();
+        final String year = createdAt.year.toString();
+        final String month = createdAt.month.toString().padLeft(2, '0');
+        final String metricsPath =
+            'local_community/$country/cities/$city/neighborhoods/$neighborhood/metrics_${year}_${month}/$postId';
+        final String postPath =
+            'local_community/$country/cities/$city/neighborhoods/$neighborhood/posts_${year}_${month}/$postId';
 
       final DocumentReference communityMetricsRef =
           FirebaseFirestore.instance.doc(metricsPath);
@@ -365,10 +382,13 @@ class PostDetailScreenState extends State<PostDetailScreen> {
 
       WriteBatch batch = FirebaseFirestore.instance.batch();
 
-      final String metricsPath =
-          'local_community/$country/cities/$city/neighborhoods/$neighborhood/metrics_${DateTime.now().year}_${DateTime.now().month.toString().padLeft(2, '0')}/$postId';
-      final String postPath =
-          'local_community/$country/cities/$city/neighborhoods/$neighborhood/posts_${DateTime.now().year}_${DateTime.now().month.toString().padLeft(2, '0')}/$postId';
+        final DateTime createdAt = (widget.post['createdAt'] as Timestamp).toDate();
+        final String year = createdAt.year.toString();
+        final String month = createdAt.month.toString().padLeft(2, '0');
+        final String metricsPath =
+            'local_community/$country/cities/$city/neighborhoods/$neighborhood/metrics_${year}_${month}/$postId';
+        final String postPath =
+            'local_community/$country/cities/$city/neighborhoods/$neighborhood/posts_${year}_${month}/$postId';
 
       final DocumentReference communityMetricsRef =
           FirebaseFirestore.instance.doc(metricsPath);
@@ -450,9 +470,12 @@ class PostDetailScreenState extends State<PostDetailScreen> {
       return;
     }
 
-    try {
-      final String metricsPath =
-          'local_community/$country/cities/$city/neighborhoods/$neighborhood/metrics_${DateTime.now().year}_${DateTime.now().month.toString().padLeft(2, '0')}/$postId';
+      try {
+        final DateTime createdAt = (widget.post['createdAt'] as Timestamp).toDate();
+        final String year = createdAt.year.toString();
+        final String month = createdAt.month.toString().padLeft(2, '0');
+        final String metricsPath =
+            'local_community/$country/cities/$city/neighborhoods/$neighborhood/metrics_${year}_${month}/$postId';
 
       await FirebaseFirestore.instance.doc(metricsPath).set(
         {

--- a/lib/local/screens/post_widget.dart
+++ b/lib/local/screens/post_widget.dart
@@ -88,8 +88,12 @@ class PostWidgetState extends State<PostWidget> {
       final city = widget.postData['localCityId'];
       final neighborhood = widget.postData['localNeighborhoodId'];
 
+      final DateTime createdAt = (widget.postData['createdAt'] as Timestamp).toDate();
+      final String year = createdAt.year.toString();
+      final String month = createdAt.month.toString().padLeft(2, '0');
+
       final metricsPath =
-          'local_community/$country/cities/$city/neighborhoods/$neighborhood/metrics_${DateTime.now().year}_${DateTime.now().month.toString().padLeft(2, '0')}/$postId';
+          'local_community/$country/cities/$city/neighborhoods/$neighborhood/metrics_${year}_${month}/$postId';
 
       DocumentSnapshot metricsSnapshot =
           await FirebaseFirestore.instance.doc(metricsPath).get();
@@ -176,11 +180,15 @@ class PostWidgetState extends State<PostWidget> {
 
       WriteBatch batch = FirebaseFirestore.instance.batch();
 
+      final DateTime createdAt = (widget.postData['createdAt'] as Timestamp).toDate();
+      final String year = createdAt.year.toString();
+      final String month = createdAt.month.toString().padLeft(2, '0');
+
       final metricsPath =
-          'local_community/$country/cities/$city/neighborhoods/$neighborhood/metrics_${DateTime.now().year}_${DateTime.now().month.toString().padLeft(2, '0')}/$postId';
+          'local_community/$country/cities/$city/neighborhoods/$neighborhood/metrics_${year}_${month}/$postId';
 
       final postPath =
-          'local_community/$country/cities/$city/neighborhoods/$neighborhood/posts_${DateTime.now().year}_${DateTime.now().month.toString().padLeft(2, '0')}/$postId';
+          'local_community/$country/cities/$city/neighborhoods/$neighborhood/posts_${year}_${month}/$postId';
 
       final communityMetricsRef = FirebaseFirestore.instance.doc(metricsPath);
       final postRef = FirebaseFirestore.instance.doc(postPath);
@@ -258,11 +266,15 @@ class PostWidgetState extends State<PostWidget> {
 
       WriteBatch batch = FirebaseFirestore.instance.batch();
 
+      final DateTime createdAt = (widget.postData['createdAt'] as Timestamp).toDate();
+      final String year = createdAt.year.toString();
+      final String month = createdAt.month.toString().padLeft(2, '0');
+
       final metricsPath =
-          'local_community/$country/cities/$city/neighborhoods/$neighborhood/metrics_${DateTime.now().year}_${DateTime.now().month.toString().padLeft(2, '0')}/$postId';
+          'local_community/$country/cities/$city/neighborhoods/$neighborhood/metrics_${year}_${month}/$postId';
 
       final postPath =
-          'local_community/$country/cities/$city/neighborhoods/$neighborhood/posts_${DateTime.now().year}_${DateTime.now().month.toString().padLeft(2, '0')}/$postId';
+          'local_community/$country/cities/$city/neighborhoods/$neighborhood/posts_${year}_${month}/$postId';
 
       final communityMetricsRef = FirebaseFirestore.instance.doc(metricsPath);
       final postRef = FirebaseFirestore.instance.doc(postPath);

--- a/lib/local/services/post_correction_service.dart
+++ b/lib/local/services/post_correction_service.dart
@@ -146,22 +146,35 @@ class PostCorrectionService {
       postData['localNeighborhoodId'] = neighborhood;
       postData['corrected'] = true; // oznaka da je post ispravljen
 
+      // Dohvati godinu i mjesec na temelju vremena kreiranja posta
+      DateTime createdAt;
+      if (postData['createdAt'] is Timestamp) {
+        createdAt = (postData['createdAt'] as Timestamp).toDate();
+      } else if (postData['createdAt'] is DateTime) {
+        createdAt = postData['createdAt'] as DateTime;
+      } else {
+        createdAt = DateTime.now();
+      }
+
+      final String year = createdAt.year.toString();
+      final String month = createdAt.month.toString().padLeft(2, '0');
+
       String newCollectionPath;
       if (postData.containsKey('localLocationId') &&
           postData['localLocationId'] == LocationConstants.UNKNOWN) {
         // Putanja za "Unknown" lokacije
         newCollectionPath =
-            'local_community/${LocationConstants.UNKNOWN}/posts_${DateTime.now().year}_${DateTime.now().month.toString().padLeft(2, '0')}';
+            'local_community/${LocationConstants.UNKNOWN}/posts_${year}_$month';
       } else if (country == LocationConstants.UNKNOWN_COUNTRY &&
           city == LocationConstants.UNKNOWN_CITY &&
           neighborhood == LocationConstants.UNKNOWN_NEIGHBORHOOD) {
         // Putanja za opću nepoznatu lokaciju
         newCollectionPath =
-            'local_community/${LocationConstants.UNKNOWN_LOCATION}/posts_${DateTime.now().year}_${DateTime.now().month.toString().padLeft(2, '0')}';
+            'local_community/${LocationConstants.UNKNOWN_LOCATION}/posts_${year}_$month';
       } else {
         // Putanja za specifičnu lokaciju
         newCollectionPath =
-            'local_community/$country/cities/$city/neighborhoods/$neighborhood/posts_${DateTime.now().year}_${DateTime.now().month.toString().padLeft(2, '0')}';
+            'local_community/$country/cities/$city/neighborhoods/$neighborhood/posts_${year}_$month';
       }
 
       // Koristimo batch ili transakciju radi konzistentnosti

--- a/lib/local/services/post_service.dart
+++ b/lib/local/services/post_service.dart
@@ -38,8 +38,17 @@ class PostService {
         postData['localLocationId'] = LocationConstants.UNKNOWN_LOCATION;
       }
 
-      final String year = DateTime.now().year.toString();
-      final String month = DateTime.now().month.toString().padLeft(2, '0');
+      DateTime createdAt;
+      if (postData['createdAt'] is Timestamp) {
+        createdAt = (postData['createdAt'] as Timestamp).toDate();
+      } else if (postData['createdAt'] is DateTime) {
+        createdAt = postData['createdAt'] as DateTime;
+      } else {
+        createdAt = DateTime.now();
+      }
+
+      final String year = createdAt.year.toString();
+      final String month = createdAt.month.toString().padLeft(2, '0');
 
       // ------------- GEO-KOLEKCIJA -------------
       final String geoPath = postData.containsKey('localLocationId') &&
@@ -81,6 +90,7 @@ class PostService {
         cityId,
         neighborhood,
         postId,
+        createdAt,
         likes: 0,
         dislikes: 0,
         views: 0,
@@ -107,8 +117,17 @@ class PostService {
     try {
       CollectionReference postCollection;
 
-      final String year = DateTime.now().year.toString();
-      final String month = DateTime.now().month.toString().padLeft(2, '0');
+      DateTime createdAt;
+      if (postData['createdAt'] is Timestamp) {
+        createdAt = (postData['createdAt'] as Timestamp).toDate();
+      } else if (postData['createdAt'] is DateTime) {
+        createdAt = postData['createdAt'] as DateTime;
+      } else {
+        createdAt = DateTime.now();
+      }
+
+      final String year = createdAt.year.toString();
+      final String month = createdAt.month.toString().padLeft(2, '0');
 
       if (isUnknownLocation) {
         postCollection = _firestore
@@ -164,8 +183,17 @@ class PostService {
     Map<String, dynamic> postData,
   ) async {
     try {
-      final String year = DateTime.now().year.toString();
-      final String month = DateTime.now().month.toString().padLeft(2, '0');
+      DateTime createdAt;
+      if (postData['createdAt'] is Timestamp) {
+        createdAt = (postData['createdAt'] as Timestamp).toDate();
+      } else if (postData['createdAt'] is DateTime) {
+        createdAt = postData['createdAt'] as DateTime;
+      } else {
+        createdAt = DateTime.now();
+      }
+
+      final String year = createdAt.year.toString();
+      final String month = createdAt.month.toString().padLeft(2, '0');
 
       final postRef = _firestore
           .collection('local_community')
@@ -213,6 +241,7 @@ class PostService {
         cityId,
         neighborhoodId,
         postId,
+        createdAt,
         likes: 1,
       );
     } catch (e) {
@@ -232,8 +261,17 @@ class PostService {
     Map<String, dynamic> postData,
   ) async {
     try {
-      final String year = DateTime.now().year.toString();
-      final String month = DateTime.now().month.toString().padLeft(2, '0');
+      DateTime createdAt;
+      if (postData['createdAt'] is Timestamp) {
+        createdAt = (postData['createdAt'] as Timestamp).toDate();
+      } else if (postData['createdAt'] is DateTime) {
+        createdAt = postData['createdAt'] as DateTime;
+      } else {
+        createdAt = DateTime.now();
+      }
+
+      final String year = createdAt.year.toString();
+      final String month = createdAt.month.toString().padLeft(2, '0');
 
       final postRef = _firestore
           .collection('local_community')
@@ -271,6 +309,7 @@ class PostService {
         cityId,
         neighborhoodId,
         postId,
+        createdAt,
         shares: 1,
       );
     } catch (e) {
@@ -287,10 +326,11 @@ class PostService {
     String countryId,
     String cityId,
     String neighborhoodId,
+    DateTime createdAt,
   ) async {
     try {
-      final String year = DateTime.now().year.toString();
-      final String month = DateTime.now().month.toString().padLeft(2, '0');
+      final String year = createdAt.year.toString();
+      final String month = createdAt.month.toString().padLeft(2, '0');
 
       final postRef = _firestore
           .collection('local_community')
@@ -323,6 +363,7 @@ class PostService {
         cityId,
         neighborhoodId,
         postId,
+        createdAt,
         views: 1,
       );
     } catch (e) {
@@ -338,10 +379,11 @@ class PostService {
     String cityId,
     String neighborhoodId,
     String postId,
+    DateTime createdAt,
   ) async {
     try {
-      final String year = DateTime.now().year.toString();
-      final String month = DateTime.now().month.toString().padLeft(2, '0');
+      final String year = createdAt.year.toString();
+      final String month = createdAt.month.toString().padLeft(2, '0');
 
       final metricsRef = _firestore
           .collection('local_community')
@@ -419,15 +461,16 @@ class PostService {
     String countryId,
     String cityId,
     String neighborhoodId,
-    String postId, {
+    String postId,
+    DateTime createdAt, {
     int likes = 0,
     int dislikes = 0,
     int views = 0,
     int shares = 0,
   }) async {
     try {
-      final String year = DateTime.now().year.toString();
-      final String month = DateTime.now().month.toString().padLeft(2, '0');
+      final String year = createdAt.year.toString();
+      final String month = createdAt.month.toString().padLeft(2, '0');
 
       final CollectionReference metricsCollection =
           (countryId == LocationConstants.UNKNOWN_COUNTRY &&


### PR DESCRIPTION
## Summary
- move posts using the original `createdAt` timestamp
- derive year/month from `createdAt` when saving or updating posts
- update metrics paths in services and screens to use the post creation date
- pass `createdAt` through view updates

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406a0bb48c83279392da0ffd68a502