### PR TITLE
Improve ad type dropdown text

### DIFF
--- a/lib/screens/bulletin_board_screen.dart
+++ b/lib/screens/bulletin_board_screen.dart
@@ -914,20 +914,9 @@ ${bulletin.description}
             padding: const EdgeInsets.all(8.0),
             child: Column(
               children: [
-                Align(
-                  alignment: Alignment.centerLeft,
-                  child: Text(
-                    localizationService.translate('select_ad_type') ??
-                        'Select ad type:',
-                    style: const TextStyle(
-                      fontWeight: FontWeight.bold,
-                      fontSize: 16,
-                    ),
-                  ),
-                ),
                 DropdownButton<String>(
                   value: _selectedAdType,
-                  items: ['Internal', 'All'].map((type) {
+                  items: ['All', 'Internal'].map((type) {
                     return DropdownMenuItem<String>(
                       value: type,
                       child: Text(


### PR DESCRIPTION
## Summary
- update bulletin board dropdown options
- remove dropdown label
- keep localization keys

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840be499bb08327ac9a40efd57b85a1