### PR TITLE
Extract news portal sections into widgets

### DIFF
--- a/lib/screens/news_portal/buka_section.dart
+++ b/lib/screens/news_portal/buka_section.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../../services/localization_service.dart';
+import '../construction_screen.dart';
+import 'widgets.dart';
+
+class BukaSection extends StatelessWidget {
+  final List<Map<String, dynamic>> works;
+  final String username;
+  final String countryId;
+  final String cityId;
+  final String locationId;
+
+  const BukaSection({
+    super.key,
+    required this.works,
+    required this.username,
+    required this.countryId,
+    required this.cityId,
+    required this.locationId,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = Provider.of<LocalizationService>(context, listen: false);
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      elevation: 3,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Column(
+        children: [
+          buildSectionHeader(
+            Icons.construction,
+            loc.translate('noise') ?? 'Buka',
+            () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => ConstructionScreen(
+                    username: username,
+                    countryId: countryId,
+                    cityId: cityId,
+                    locationId: locationId,
+                  ),
+                ),
+              );
+            },
+          ),
+          works.isEmpty
+              ? Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Text(
+                      loc.translate('no_active_works') ?? 'Trenutno nema radova.'),
+                )
+              : ListView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  itemCount: works.length,
+                  itemBuilder: (context, index) {
+                    final work = works[index];
+                    final String description = work['description'] ?? '';
+                    final String details = work['details'] ?? '';
+                    final DateTime startDate = DateTime.parse(work['startDate']);
+                    final DateTime endDate = DateTime.parse(work['endDate']);
+                    final dateFormat = DateFormat('dd.MM.yyyy');
+                    return Card(
+                      margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+                      elevation: 2,
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                      child: Padding(
+                        padding: const EdgeInsets.all(12),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              description,
+                              style: const TextStyle(
+                                  fontWeight: FontWeight.bold, fontSize: 16),
+                            ),
+                            const SizedBox(height: 5),
+                            Text(details),
+                            const SizedBox(height: 5),
+                            Text(
+                              '${loc.translate('date') ?? 'Date'}: ${dateFormat.format(startDate)} - ${dateFormat.format(endDate)}',
+                              style: const TextStyle(fontSize: 12),
+                            ),
+                          ],
+                        ),
+                      ),
+                    );
+                  },
+                ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/news_portal/bulletin_board_section.dart
+++ b/lib/screens/news_portal/bulletin_board_section.dart
@@ -1,0 +1,155 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/bulletin.dart';
+import '../../services/localization_service.dart';
+import '../bulletin_board_screen.dart';
+import '../full_screen_bulletin.dart';
+import 'widgets.dart';
+
+class BulletinBoardSection extends StatelessWidget {
+  final String username;
+  final String countryId;
+  final String cityId;
+  final String locationId;
+  final String geoCountry;
+  final String geoCity;
+  final String geoNeighborhood;
+  final FirebaseFirestore firestore;
+
+  const BulletinBoardSection({
+    super.key,
+    required this.username,
+    required this.countryId,
+    required this.cityId,
+    required this.locationId,
+    required this.geoCountry,
+    required this.geoCity,
+    required this.geoNeighborhood,
+    required this.firestore,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = Provider.of<LocalizationService>(context, listen: false);
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      elevation: 3,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Column(
+        children: [
+          buildSectionHeader(
+            Icons.announcement,
+            loc.translate('bulletin_board') ?? 'Bulletin Board',
+            () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => BulletinBoardScreen(
+                    username: username,
+                    countryId: countryId,
+                    cityId: cityId,
+                    locationId: locationId,
+                  ),
+                ),
+              );
+            },
+          ),
+          FutureBuilder<QuerySnapshot>(
+            future: firestore
+                .collection('countries')
+                .doc(geoCountry.isNotEmpty ? geoCountry : countryId)
+                .collection('cities')
+                .doc(geoCity.isNotEmpty ? geoCity : cityId)
+                .collection('locations')
+                .doc(geoNeighborhood.isNotEmpty ? geoNeighborhood : locationId)
+                .collection('bulletin_board')
+                .orderBy('createdAt', descending: true)
+                .limit(2)
+                .get(),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(
+                  child: Padding(
+                    padding: EdgeInsets.all(16.0),
+                    child: CircularProgressIndicator(),
+                  ),
+                );
+              } else if (snapshot.hasError) {
+                return Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Text(
+                      loc.translate('error_loading_data') ?? 'Error loading data.',
+                    ),
+                  ),
+                );
+              } else if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+                return Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Text(
+                      loc.translate('no_data_available') ?? 'No data available.',
+                    ),
+                  ),
+                );
+              }
+              final docs = snapshot.data!.docs;
+              return Column(
+                children: docs.map((doc) {
+                  final data = doc.data() as Map<String, dynamic>;
+                  final List<dynamic> imagePaths = data['imagePaths'] ?? <dynamic>[];
+                  String firstImage = 'assets/images/bulletin.png';
+                  if (imagePaths.isNotEmpty && imagePaths[0] is String) {
+                    firstImage = imagePaths[0];
+                  }
+                  final String itemTitle = data['title'] as String? ?? '';
+                  final Timestamp ts = (data['createdAt'] is Timestamp)
+                      ? data['createdAt'] as Timestamp
+                      : Timestamp.now();
+                  final DateTime createdAt = ts.toDate();
+                  final Bulletin bullet = Bulletin.fromMap(data, doc.id);
+                  return GestureDetector(
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => FullScreenBulletin(
+                            bulletin: bullet,
+                            username: username,
+                            countryId: countryId,
+                            cityId: cityId,
+                            locationId: locationId,
+                          ),
+                        ),
+                      );
+                    },
+                    child: Card(
+                      margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+                      elevation: 2,
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                      child: ListTile(
+                        leading: const Icon(Icons.insert_drive_file, size: 48, color: Colors.grey),
+                        title: Text(
+                          itemTitle,
+                          style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        subtitle: Text(
+                          formatTimeAgo(createdAt, loc),
+                          style: const TextStyle(fontSize: 10, color: Colors.grey),
+                        ),
+                      ),
+                    ),
+                  );
+                }).toList(),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/news_portal/chat_room_section.dart
+++ b/lib/screens/news_portal/chat_room_section.dart
@@ -1,0 +1,196 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+
+import '../../models/chat_model.dart';
+import '../../services/localization_service.dart';
+import '../group_chat_page.dart';
+import 'widgets.dart';
+
+class ChatRoomSection extends StatelessWidget {
+  final String countryId;
+  final String cityId;
+  final String locationId;
+  final String geoCountry;
+  final String geoCity;
+  final String geoNeighborhood;
+  final FirebaseFirestore firestore;
+
+  const ChatRoomSection({
+    super.key,
+    required this.countryId,
+    required this.cityId,
+    required this.locationId,
+    required this.geoCountry,
+    required this.geoCity,
+    required this.geoNeighborhood,
+    required this.firestore,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = Provider.of<LocalizationService>(context, listen: false);
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      elevation: 3,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Column(
+        children: [
+          buildSectionHeader(
+            Icons.chat,
+            loc.translate('chat') ?? 'Chat',
+            () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => GroupChatPage(
+                    countryId: countryId,
+                    cityId: cityId,
+                    locationId: locationId,
+                  ),
+                ),
+              );
+            },
+          ),
+          FutureBuilder<QuerySnapshot>(
+            future: firestore
+                .collection('countries')
+                .doc(geoCountry.isNotEmpty ? geoCountry : countryId)
+                .collection('cities')
+                .doc(geoCity.isNotEmpty ? geoCity : cityId)
+                .collection('locations')
+                .doc(geoNeighborhood.isNotEmpty ? geoNeighborhood : locationId)
+                .collection('chats')
+                .orderBy('createdAt', descending: true)
+                .limit(5)
+                .get(),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(
+                  child: Padding(
+                    padding: EdgeInsets.all(16.0),
+                    child: CircularProgressIndicator(),
+                  ),
+                );
+              } else if (snapshot.hasError) {
+                return Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Text(
+                      loc.translate('error_loading_chats') ?? 'Error loading chats.',
+                    ),
+                  ),
+                );
+              } else if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+                return Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Text(
+                      loc.translate('no_chat_messages_available') ??
+                          'No chat messages available.',
+                    ),
+                  ),
+                );
+              }
+              final docs = snapshot.data!.docs;
+              final List<ChatModel> lastMessages = docs
+                  .map((doc) => ChatModel.fromJson(doc.data() as Map<String, dynamic>))
+                  .toList();
+              return Column(
+                children:
+                    lastMessages.map((chat) => _SingleChatMessage(chat: chat, loc: loc, countryId: countryId, cityId: cityId, locationId: locationId)).toList(),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SingleChatMessage extends StatelessWidget {
+  final ChatModel chat;
+  final LocalizationService loc;
+  final String countryId;
+  final String cityId;
+  final String locationId;
+
+  const _SingleChatMessage({
+    required this.chat,
+    required this.loc,
+    required this.countryId,
+    required this.cityId,
+    required this.locationId,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final String profileImg = chat.profileImageUrl.isNotEmpty
+        ? chat.profileImageUrl
+        : 'assets/images/default_user.png';
+    final String messageText = chat.text;
+    final DateTime timeSent = chat.createdAt.toDate();
+    return GestureDetector(
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => GroupChatPage(
+              countryId: countryId,
+              cityId: cityId,
+              locationId: locationId,
+            ),
+          ),
+        );
+      },
+      child: Card(
+        margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+        elevation: 2,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        child: Padding(
+          padding: const EdgeInsets.all(8),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              ClipOval(child: buildImage(profileImg, width: 40, height: 40)),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      chat.user.isNotEmpty ? chat.user : 'Unknown User',
+                      style: const TextStyle(
+                          fontWeight: FontWeight.bold, fontSize: 14),
+                    ),
+                    const SizedBox(height: 4),
+                    if (messageText.isNotEmpty)
+                      Text(messageText, style: const TextStyle(fontSize: 14)),
+                    if (chat.imageUrl.isNotEmpty) ...[
+                      const SizedBox(height: 8),
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: CachedNetworkImage(
+                          imageUrl: chat.imageUrl,
+                          placeholder: (context, url) => const CircularProgressIndicator(),
+                          errorWidget: (context, url, error) => const Icon(Icons.error),
+                          fit: BoxFit.cover,
+                        ),
+                      ),
+                    ],
+                    const SizedBox(height: 4),
+                    Text(
+                      formatTimeAgo(timeSent, loc),
+                      style: const TextStyle(color: Colors.grey, fontSize: 11),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/news_portal/commute_section.dart
+++ b/lib/screens/news_portal/commute_section.dart
@@ -1,0 +1,227 @@
+import 'dart:async';
+
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/ride_model.dart';
+import '../../services/localization_service.dart';
+import '../commute_screens/commute_ride_detail_screen.dart';
+import '../commute_screens/commute_rides_list_screen.dart';
+import 'widgets.dart';
+
+class CommuteSection extends StatelessWidget {
+  final List<Ride> commutePreview;
+  final String username;
+  final String countryId;
+  final String cityId;
+  final String locationId;
+  final FirebaseAuth? auth;
+  final Map<String, Completer<GoogleMapController>> smallMapControllers;
+  final String Function(DateTime, LocalizationService) formatTimeAgo;
+
+  const CommuteSection({
+    super.key,
+    required this.commutePreview,
+    required this.username,
+    required this.countryId,
+    required this.cityId,
+    required this.locationId,
+    required this.auth,
+    required this.smallMapControllers,
+    required this.formatTimeAgo,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = Provider.of<LocalizationService>(context, listen: false);
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      elevation: 3,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Column(
+        children: [
+          buildSectionHeader(
+            Icons.directions_car,
+            loc.translate('commute') ?? 'Zajednički prijevoz',
+            () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => CommuteRidesListScreen(
+                    username: username,
+                    countryId: countryId,
+                    cityId: cityId,
+                    locationId: locationId,
+                  ),
+                ),
+              );
+            },
+          ),
+          commutePreview.isEmpty
+              ? Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                  child: Text(
+                    loc.translate('no_offered_rides') ?? 'Trenutno nema ponuđenih vožnji.',
+                  ),
+                )
+              : Column(
+                  children: commutePreview
+                      .map(
+                        (ride) => GestureDetector(
+                          onTap: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (_) => CommuteRideDetailScreen(
+                                  rideId: ride.rideId,
+                                  userId: auth?.currentUser?.uid ?? '',
+                                ),
+                              ),
+                            );
+                          },
+                          child: _CommutePreviewCard(
+                            ride: ride,
+                            loc: loc,
+                            formatTimeAgo: formatTimeAgo,
+                            mapControllers: smallMapControllers,
+                          ),
+                        ),
+                      )
+                      .toList(),
+                ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CommutePreviewCard extends StatelessWidget {
+  final Ride ride;
+  final LocalizationService loc;
+  final String Function(DateTime, LocalizationService) formatTimeAgo;
+  final Map<String, Completer<GoogleMapController>> mapControllers;
+
+  const _CommutePreviewCard({
+    required this.ride,
+    required this.loc,
+    required this.formatTimeAgo,
+    required this.mapControllers,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final String driverName = ride.driverName;
+    final DateTime createdAt = ride.createdAt.toDate();
+    final double startLat = ride.startLocation.latitude;
+    final double startLng = ride.startLocation.longitude;
+    final double endLat = ride.endLocation.latitude;
+    final double endLng = ride.endLocation.longitude;
+    final String rideId = ride.rideId;
+
+    List<LatLng> routeLatLng = [];
+    for (var gp in ride.route) {
+      routeLatLng.add(LatLng(gp.latitude, gp.longitude));
+    }
+    mapControllers.putIfAbsent(rideId, () => Completer<GoogleMapController>());
+
+    final startMarker = Marker(
+      markerId: MarkerId('start_$rideId'),
+      position: LatLng(startLat, startLng),
+      icon: BitmapDescriptor.defaultMarkerWithHue(BitmapDescriptor.hueGreen),
+    );
+    final endMarker = Marker(
+      markerId: MarkerId('end_$rideId'),
+      position: LatLng(endLat, endLng),
+      icon: BitmapDescriptor.defaultMarkerWithHue(BitmapDescriptor.hueRed),
+    );
+    final markers = {startMarker, endMarker};
+
+    final Set<Polyline> polylines = {};
+    if (routeLatLng.isNotEmpty) {
+      polylines.add(
+        Polyline(
+          polylineId: PolylineId('ride_$rideId'),
+          color: Colors.blue,
+          width: 4,
+          points: routeLatLng,
+        ),
+      );
+    }
+
+    final List<LatLng> latLngList = [
+      LatLng(startLat, startLng),
+      LatLng(endLat, endLng),
+      ...routeLatLng
+    ];
+    LatLngBounds? bounds;
+    if (latLngList.isNotEmpty) {
+      double minLat = latLngList.first.latitude;
+      double maxLat = latLngList.first.latitude;
+      double minLng = latLngList.first.longitude;
+      double maxLng = latLngList.first.longitude;
+      for (var ll in latLngList) {
+        if (ll.latitude < minLat) minLat = ll.latitude;
+        if (ll.latitude > maxLat) maxLat = ll.latitude;
+        if (ll.longitude < minLng) minLng = ll.longitude;
+        if (ll.longitude > maxLng) maxLng = ll.longitude;
+      }
+      bounds = LatLngBounds(
+        southwest: LatLng(minLat, minLng),
+        northeast: LatLng(maxLat, maxLng),
+      );
+    }
+
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '${loc.translate('driver') ?? 'Driver'}: $driverName',
+              style: const TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 4),
+            Text('${loc.translate('start_address') ?? 'Polazište'}: ${ride.startAddress}'),
+            Text('${loc.translate('destination') ?? 'Odredište'}: ${ride.endAddress}'),
+            const SizedBox(height: 4),
+            Text(
+              '${loc.translate('published') ?? 'Objavljeno'}: ${formatTimeAgo(createdAt, loc)}',
+              style: const TextStyle(fontSize: 12, color: Colors.grey),
+            ),
+            const SizedBox(height: 8),
+            SizedBox(
+              height: 120,
+              child: GoogleMap(
+                onMapCreated: (controller) async {
+                  if (!mapControllers[rideId]!.isCompleted) {
+                    mapControllers[rideId]!.complete(controller);
+                  }
+                  if (bounds != null) {
+                    await Future.delayed(const Duration(milliseconds: 300));
+                    controller.animateCamera(
+                      CameraUpdate.newLatLngBounds(bounds, 50),
+                    );
+                  }
+                },
+                markers: markers,
+                polylines: polylines,
+                initialCameraPosition: CameraPosition(
+                  target: LatLng(startLat, startLng),
+                  zoom: 4.5,
+                ),
+                zoomControlsEnabled: false,
+                myLocationEnabled: false,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/news_portal/documents_section.dart
+++ b/lib/screens/news_portal/documents_section.dart
@@ -1,0 +1,142 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../services/localization_service.dart';
+import '../document_preview_screen.dart';
+import '../documents_screen.dart';
+import 'widgets.dart';
+
+class DocumentsSection extends StatelessWidget {
+  final String username;
+  final String countryId;
+  final String cityId;
+  final String locationId;
+  final String geoCountry;
+  final String geoCity;
+  final String geoNeighborhood;
+  final FirebaseFirestore firestore;
+  final Future<void> Function(Map<String, dynamic>) openDocument;
+
+  const DocumentsSection({
+    super.key,
+    required this.username,
+    required this.countryId,
+    required this.cityId,
+    required this.locationId,
+    required this.geoCountry,
+    required this.geoCity,
+    required this.geoNeighborhood,
+    required this.firestore,
+    required this.openDocument,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = Provider.of<LocalizationService>(context, listen: false);
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      color: Colors.orange[50],
+      elevation: 3,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Column(
+        children: [
+          buildSectionHeader(
+            Icons.description,
+            loc.translate('documents') ?? 'Documents',
+            () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => DocumentsScreen(
+                    username: username,
+                    countryId: countryId,
+                    cityId: cityId,
+                    locationId: locationId,
+                  ),
+                ),
+              );
+            },
+            headerColor: Colors.grey,
+          ),
+          FutureBuilder<QuerySnapshot>(
+            future: firestore
+                .collection('countries')
+                .doc(geoCountry.isNotEmpty ? geoCountry : countryId)
+                .collection('cities')
+                .doc(geoCity.isNotEmpty ? geoCity : cityId)
+                .collection('locations')
+                .doc(geoNeighborhood.isNotEmpty ? geoNeighborhood : locationId)
+                .collection('documents')
+                .orderBy('createdAt', descending: true)
+                .limit(2)
+                .get(),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(
+                  child: Padding(
+                    padding: EdgeInsets.all(16.0),
+                    child: CircularProgressIndicator(),
+                  ),
+                );
+              } else if (snapshot.hasError) {
+                return Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Text(
+                      loc.translate('error_loading_data') ?? 'Error loading data.',
+                    ),
+                  ),
+                );
+              } else if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+                return Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Text(
+                      loc.translate('no_data_available') ?? 'No data available.',
+                    ),
+                  ),
+                );
+              }
+              final docs = snapshot.data!.docs;
+              return Column(
+                children: docs.map((doc) {
+                  final data = doc.data() as Map<String, dynamic>;
+                  final String itemTitle = data['title'] as String? ?? '';
+                  final Timestamp ts = (data['createdAt'] is Timestamp)
+                      ? data['createdAt'] as Timestamp
+                      : Timestamp.now();
+                  final DateTime createdAt = ts.toDate();
+                  return GestureDetector(
+                    onTap: () {
+                      final docMap = {'id': doc.id, ...data};
+                      openDocument(docMap);
+                    },
+                    child: Card(
+                      margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+                      elevation: 2,
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                      child: ListTile(
+                        leading: const Icon(Icons.insert_drive_file, size: 48, color: Colors.grey),
+                        title: Text(
+                          itemTitle,
+                          style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        subtitle: Text(
+                          formatTimeAgo(createdAt, loc),
+                          style: const TextStyle(fontSize: 10, color: Colors.grey),
+                        ),
+                      ),
+                    ),
+                  );
+                }).toList(),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/news_portal/last_posts_section.dart
+++ b/lib/screens/news_portal/last_posts_section.dart
@@ -1,0 +1,205 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../services/localization_service.dart';
+import '../local/screens/local_home_screen.dart';
+import '../local/screens/post_detail_screen.dart';
+import 'widgets.dart';
+
+class LastPostsSection extends StatelessWidget {
+  final Future<List<Map<String, dynamic>>> Function() fetchPosts;
+  final String username;
+  final bool locationAdmin;
+
+  const LastPostsSection({
+    super.key,
+    required this.fetchPosts,
+    required this.username,
+    required this.locationAdmin,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = Provider.of<LocalizationService>(context, listen: false);
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      elevation: 3,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Column(
+        children: [
+          buildSectionHeader(
+            Icons.article,
+            loc.translate('last_posts') ?? 'Zadnji postovi',
+            () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => LocalHomeScreen(
+                    username: username,
+                    locationAdmin: locationAdmin,
+                  ),
+                ),
+              );
+            },
+          ),
+          FutureBuilder<List<Map<String, dynamic>>>(
+            future: fetchPosts(),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const SizedBox(
+                  height: 200,
+                  child: Center(child: CircularProgressIndicator()),
+                );
+              } else if (snapshot.hasError) {
+                return SizedBox(
+                  height: 200,
+                  child: Center(
+                    child: Text(
+                      loc.translate('error_loading_posts') ?? 'Error loading posts',
+                    ),
+                  ),
+                );
+              } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+                return SizedBox(
+                  height: 200,
+                  child: Center(
+                    child: Text(
+                      loc.translate('no_posts_available') ?? 'No posts available',
+                    ),
+                  ),
+                );
+              }
+              final posts = snapshot.data!;
+              return Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: GridView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  itemCount: posts.length,
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 2,
+                    crossAxisSpacing: 8,
+                    mainAxisSpacing: 8,
+                    childAspectRatio: 1,
+                  ),
+                  itemBuilder: (context, index) {
+                    final post = posts[index];
+                    final String imageUrl = post['mediaUrl'] as String? ?? '';
+                    final String title = post['title'] as String? ?? '';
+                    final Timestamp ts = (post['createdAt'] is Timestamp)
+                        ? post['createdAt'] as Timestamp
+                        : Timestamp.now();
+                    final DateTime createdAt = ts.toDate();
+                    final String userName = post['createdBy'] as String? ?? '';
+                    final String userLocation =
+                        post['localNeighborhoodId'] as String? ?? '';
+                    return GestureDetector(
+                      onTap: () {
+                        final postMap = {
+                          'postId': post['postId'],
+                          'userId': post['userId'] ?? '',
+                          'localCountryId': post['localCountryId'] ?? '',
+                          'localCityId': post['localCityId'] ?? '',
+                          'localNeighborhoodId': post['localNeighborhoodId'] ?? '',
+                          'isVideo': post['isVideo'] ?? false,
+                          'mediaUrl': post['mediaUrl'] ?? '',
+                          'aspectRatio': post['aspectRatio'] ?? 1.0,
+                          'createdAt': post['createdAt'] ?? Timestamp.now(),
+                          'text': post['text'] ?? '',
+                          'views': post['views'] ?? 0,
+                        };
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => PostDetailScreen(post: postMap),
+                          ),
+                        );
+                      },
+                      child: Card(
+                        elevation: 2,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        clipBehavior: Clip.antiAlias,
+                        child: Stack(
+                          children: [
+                            Positioned.fill(
+                              child: buildImage(
+                                imageUrl,
+                                width: double.infinity,
+                                height: double.infinity,
+                                fit: BoxFit.cover,
+                              ),
+                            ),
+                            Positioned(
+                              bottom: 0,
+                              left: 0,
+                              right: 0,
+                              child: Container(
+                                color: Colors.black.withOpacity(0.5),
+                                padding: const EdgeInsets.all(8.0),
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    if (title.isNotEmpty)
+                                      Text(
+                                        title,
+                                        style: const TextStyle(
+                                          color: Colors.white,
+                                          fontSize: 14,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                        maxLines: 2,
+                                        overflow: TextOverflow.ellipsis,
+                                      ),
+                                    if (userName.isNotEmpty)
+                                      Padding(
+                                        padding: const EdgeInsets.only(top: 4.0),
+                                        child: Text(
+                                          userName,
+                                          style: const TextStyle(
+                                            color: Colors.white70,
+                                            fontSize: 12,
+                                          ),
+                                        ),
+                                      ),
+                                    if (userLocation.isNotEmpty)
+                                      Padding(
+                                        padding: const EdgeInsets.only(top: 2.0),
+                                        child: Text(
+                                          userLocation,
+                                          style: const TextStyle(
+                                            color: Colors.white70,
+                                            fontSize: 12,
+                                          ),
+                                        ),
+                                      ),
+                                    Padding(
+                                      padding: const EdgeInsets.only(top: 2.0),
+                                      child: Text(
+                                        formatTimeAgo(createdAt, loc),
+                                        style: const TextStyle(
+                                          color: Colors.white60,
+                                          fontSize: 10,
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/news_portal/marketplace_section.dart
+++ b/lib/screens/news_portal/marketplace_section.dart
@@ -1,0 +1,174 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../services/localization_service.dart';
+import '../ad_detail_screen.dart';
+import '../marketplace_screen.dart';
+import 'widgets.dart';
+
+class MarketplaceSection extends StatelessWidget {
+  final Future<List<Map<String, dynamic>>> Function() fetchAds;
+  final String username;
+  final String countryId;
+  final String cityId;
+  final String locationId;
+
+  const MarketplaceSection({
+    super.key,
+    required this.fetchAds,
+    required this.username,
+    required this.countryId,
+    required this.cityId,
+    required this.locationId,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = Provider.of<LocalizationService>(context, listen: false);
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      elevation: 3,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Column(
+        children: [
+          buildSectionHeader(
+            Icons.store,
+            loc.translate('marketplace') ?? 'Tržnica',
+            () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => MarketplaceScreen(
+                    username: username,
+                    countryId: countryId,
+                    cityId: cityId,
+                    locationId: locationId,
+                  ),
+                ),
+              );
+            },
+          ),
+          FutureBuilder<List<Map<String, dynamic>>>(
+            future: fetchAds(),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(
+                  child: SizedBox(height: 100, child: CircularProgressIndicator()),
+                );
+              } else if (snapshot.hasError) {
+                return Center(
+                  child: Text(
+                    loc.translate('error_loading_marketplace_ads') ??
+                        'Error loading marketplace ads.',
+                  ),
+                );
+              } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+                return Center(
+                  child: Text(
+                    loc.translate('no_ads_available') ?? 'No ads available.',
+                  ),
+                );
+              }
+              final adsData = snapshot.data!;
+              return Column(
+                children:
+                    adsData.map((ad) => _MarketplaceCard(ad: ad, loc: loc, countryId: countryId, cityId: cityId, locationId: locationId)).toList(),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MarketplaceCard extends StatelessWidget {
+  final Map<String, dynamic> ad;
+  final LocalizationService loc;
+  final String countryId;
+  final String cityId;
+  final String locationId;
+
+  const _MarketplaceCard({
+    required this.ad,
+    required this.loc,
+    required this.countryId,
+    required this.cityId,
+    required this.locationId,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final List<dynamic> adImages = ad['imageUrls'] ?? ad['images'] ?? [];
+    String imageUrl = '';
+    if (adImages.isNotEmpty && adImages[0] is String) {
+      imageUrl = adImages[0];
+    } else {
+      imageUrl = ad['imageUrl'] ?? '';
+    }
+    final String title = ad['title'] ?? 'No Title';
+    final String adDescription = ad['description'] ?? '';
+    final Timestamp ts = (ad['createdAt'] is Timestamp)
+        ? ad['createdAt'] as Timestamp
+        : Timestamp.now();
+    final DateTime createdAt = ts.toDate();
+    return GestureDetector(
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => AdDetailScreen(
+              ad: ad,
+              countryId: countryId,
+              cityId: cityId,
+              locationId: locationId,
+            ),
+          ),
+        );
+      },
+      child: Card(
+        margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+        elevation: 2,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        child: Row(
+          children: [
+            buildImage(imageUrl, width: 100, height: 100, fit: BoxFit.cover),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 14,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      adDescription,
+                      style: const TextStyle(fontSize: 12, color: Colors.black87),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      formatTimeAgo(createdAt, loc),
+                      style: const TextStyle(fontSize: 10, color: Colors.grey),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/news_portal/news_portal_sections.dart
+++ b/lib/screens/news_portal/news_portal_sections.dart
@@ -1,0 +1,11 @@
+export 'last_posts_section.dart';
+export 'official_notices_section.dart';
+export 'marketplace_section.dart';
+export 'chat_room_section.dart';
+export 'quiz_section.dart';
+export 'bulletin_board_section.dart';
+export 'documents_section.dart';
+export 'buka_section.dart';
+export 'parking_section.dart';
+export 'commute_section.dart';
+export 'widgets.dart';

--- a/lib/screens/news_portal/official_notices_section.dart
+++ b/lib/screens/news_portal/official_notices_section.dart
@@ -1,0 +1,215 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/blog_model.dart';
+import '../../services/localization_service.dart';
+import '../blog_details_screen.dart';
+import '../blog_screen.dart';
+import 'widgets.dart';
+
+class OfficialNoticesSection extends StatelessWidget {
+  final String username;
+  final String countryId;
+  final String cityId;
+  final String locationId;
+  final String geoCountry;
+  final String geoCity;
+  final String geoNeighborhood;
+  final bool locationAdmin;
+  final FirebaseFirestore firestore;
+
+  const OfficialNoticesSection({
+    super.key,
+    required this.username,
+    required this.countryId,
+    required this.cityId,
+    required this.locationId,
+    required this.geoCountry,
+    required this.geoCity,
+    required this.geoNeighborhood,
+    required this.locationAdmin,
+    required this.firestore,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = Provider.of<LocalizationService>(context, listen: false);
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      elevation: 3,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Column(
+        children: [
+          buildSectionHeader(
+            Icons.campaign,
+            loc.translate('official_notices') ?? 'Službene obavijesti',
+            () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => BlogScreen(
+                    username: username,
+                    countryId: countryId,
+                    cityId: cityId,
+                    locationId: locationId,
+                  ),
+                ),
+              );
+            },
+          ),
+          StreamBuilder<QuerySnapshot>(
+            stream: firestore
+                .collection('countries')
+                .doc(geoCountry.isNotEmpty ? geoCountry : countryId)
+                .collection('cities')
+                .doc(geoCity.isNotEmpty ? geoCity : cityId)
+                .collection('locations')
+                .doc(geoNeighborhood.isNotEmpty ? geoNeighborhood : locationId)
+                .collection('blogs')
+                .orderBy('createdAt', descending: true)
+                .limit(2)
+                .snapshots(),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(
+                  child: Padding(
+                    padding: EdgeInsets.all(16.0),
+                    child: CircularProgressIndicator(),
+                  ),
+                );
+              }
+              if (snapshot.hasError) {
+                return Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Text(
+                      loc.translate('error_loading_data') ?? 'Error loading data.',
+                    ),
+                  ),
+                );
+              }
+              if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+                return Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Text(
+                      loc.translate('no_official_notices') ??
+                          'No official notices available.',
+                    ),
+                  ),
+                );
+              }
+              final docs = snapshot.data!.docs;
+              List<Blog> blogs = docs
+                  .map((doc) => Blog.fromMap(doc.data() as Map<String, dynamic>, doc.id))
+                  .toList();
+              return Column(
+                children: blogs.map((blog) {
+                  final String imageUrl = blog.imageUrls.isNotEmpty
+                      ? blog.imageUrls.first
+                      : 'assets/images/tenant.png';
+                  final Timestamp ts = (blog.createdAt is Timestamp)
+                      ? blog.createdAt as Timestamp
+                      : Timestamp.now();
+                  final DateTime createdAt = ts.toDate();
+                  return GestureDetector(
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => BlogDetailsScreen(
+                            blog: blog,
+                            username: username,
+                            countryId: countryId,
+                            cityId: cityId,
+                            locationId: locationId,
+                            locationAdmin: locationAdmin,
+                          ),
+                        ),
+                      );
+                    },
+                    child: Card(
+                      margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                      elevation: 2,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      clipBehavior: Clip.antiAlias,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Stack(
+                            children: [
+                              imageUrl.isNotEmpty
+                                  ? CachedNetworkImage(
+                                      imageUrl: imageUrl,
+                                      width: double.infinity,
+                                      height: 150,
+                                      fit: BoxFit.cover,
+                                      placeholder: (context, url) =>
+                                          const Center(child: CircularProgressIndicator()),
+                                      errorWidget: (context, url, error) => Image.asset(
+                                        'assets/images/tenant.png',
+                                        width: double.infinity,
+                                        height: 150,
+                                        fit: BoxFit.cover,
+                                      ),
+                                    )
+                                  : Image.asset(
+                                      'assets/images/tenant.png',
+                                      width: double.infinity,
+                                      height: 150,
+                                      fit: BoxFit.cover,
+                                    ),
+                              Positioned(
+                                bottom: 0,
+                                left: 0,
+                                right: 0,
+                                child: Container(
+                                  color: Colors.black.withOpacity(0.6),
+                                  padding: const EdgeInsets.all(8),
+                                  child: Text(
+                                    blog.title,
+                                    style: const TextStyle(
+                                      color: Colors.white,
+                                      fontSize: 20,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.all(8.0),
+                            child: Text(
+                              blog.content.length > 100
+                                  ? '${blog.content.substring(0, 100)}...'
+                                  : blog.content,
+                              style: const TextStyle(fontSize: 14),
+                              maxLines: 3,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                            child: Text(
+                              formatTimeAgo(createdAt, loc),
+                              style: const TextStyle(fontSize: 10, color: Colors.grey),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                }).toList(),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/news_portal/parking_section.dart
+++ b/lib/screens/news_portal/parking_section.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/parking_request.dart';
+import '../../services/localization_service.dart';
+import '../parking_community_screen.dart';
+import 'widgets.dart';
+
+class ParkingSection extends StatelessWidget {
+  final List<ParkingRequest> parkingPreview;
+  final String username;
+  final String countryId;
+  final String cityId;
+  final String locationId;
+  final bool locationAdmin;
+  final String Function(DateTime, String) formatDateTime;
+
+  const ParkingSection({
+    super.key,
+    required this.parkingPreview,
+    required this.username,
+    required this.countryId,
+    required this.cityId,
+    required this.locationId,
+    required this.locationAdmin,
+    required this.formatDateTime,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = Provider.of<LocalizationService>(context, listen: false);
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      elevation: 3,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Column(
+        children: [
+          buildSectionHeader(
+            Icons.local_parking,
+            loc.translate('parking') ?? 'Parking',
+            () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => ParkingCommunityScreen(
+                    username: username,
+                    countryId: countryId,
+                    cityId: cityId,
+                    locationId: locationId,
+                    locationAdmin: locationAdmin,
+                  ),
+                ),
+              );
+            },
+          ),
+          Container(
+            margin: const EdgeInsets.all(16),
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: parkingPreview.isEmpty
+                ? Text(
+                    loc.translate('no_active_parking_requests') ??
+                        'Trenutno nema aktivnih (pending) parking zahtjeva.',
+                  )
+                : Column(
+                    children: parkingPreview
+                        .map((req) => GestureDetector(
+                              onTap: () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (context) => ParkingCommunityScreen(
+                                      username: username,
+                                      countryId: countryId,
+                                      cityId: cityId,
+                                      locationId: locationId,
+                                      locationAdmin: locationAdmin,
+                                    ),
+                                  ),
+                                );
+                              },
+                              child: _ParkingRequestPreview(
+                                req: req,
+                                loc: loc,
+                                formatDateTime: formatDateTime,
+                              ),
+                            ))
+                        .toList(),
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ParkingRequestPreview extends StatelessWidget {
+  final ParkingRequest req;
+  final LocalizationService loc;
+  final String Function(DateTime, String) formatDateTime;
+
+  const _ParkingRequestPreview({
+    required this.req,
+    required this.loc,
+    required this.formatDateTime,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final String timeString =
+        '${formatDateTime(req.startDate, req.startTime)} - ${formatDateTime(req.endDate, req.endTime)}';
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '${loc.translate('parking_request_for') ?? 'Zahtjev za'} ${req.numberOfSpots} ${loc.translate('spot_s') ?? 'mjesto(a)'}',
+              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                const Icon(Icons.access_time, size: 16, color: Colors.grey),
+                const SizedBox(width: 4),
+                Expanded(
+                  child: Text(
+                    timeString,
+                    style: const TextStyle(fontSize: 14, color: Colors.grey),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            if (req.message.isNotEmpty)
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Icon(Icons.message, size: 16, color: Colors.grey),
+                  const SizedBox(width: 4),
+                  Expanded(
+                    child: Text(
+                      req.message,
+                      style: const TextStyle(fontSize: 14, color: Colors.black87),
+                    ),
+                  ),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/news_portal/quiz_section.dart
+++ b/lib/screens/news_portal/quiz_section.dart
@@ -1,0 +1,141 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../services/localization_service.dart';
+import '../games_screen.dart';
+import 'widgets.dart';
+import '../news_portal_view.dart' show ProfileAvatar; // to use ProfileAvatar class defined there
+
+class QuizSection extends StatelessWidget {
+  final String username;
+  final String countryId;
+  final String cityId;
+  final String locationId;
+  final String geoCountry;
+  final String geoCity;
+  final String geoNeighborhood;
+  final FirebaseFirestore firestore;
+
+  const QuizSection({
+    super.key,
+    required this.username,
+    required this.countryId,
+    required this.cityId,
+    required this.locationId,
+    required this.geoCountry,
+    required this.geoCity,
+    required this.geoNeighborhood,
+    required this.firestore,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = Provider.of<LocalizationService>(context, listen: false);
+    final DateTime today = DateTime.now();
+    final String todayId =
+        '${today.year}-${today.month.toString().padLeft(2, '0')}-${today.day.toString().padLeft(2, '0')}';
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      elevation: 3,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Column(
+        children: [
+          buildSectionHeader(
+            Icons.quiz,
+            loc.translate('quiz') ?? 'Kviz',
+            () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => GamesScreen(
+                    username: username,
+                    countryId: countryId,
+                    cityId: cityId,
+                    locationId: locationId,
+                  ),
+                ),
+              );
+            },
+          ),
+          FutureBuilder<QuerySnapshot>(
+            future: firestore
+                .collection('countries')
+                .doc(geoCountry.isNotEmpty ? geoCountry : countryId)
+                .collection('cities')
+                .doc(geoCity.isNotEmpty ? geoCity : cityId)
+                .collection('locations')
+                .doc(geoNeighborhood.isNotEmpty ? geoNeighborhood : locationId)
+                .collection('quizz')
+                .doc(todayId)
+                .collection('results')
+                .orderBy('score', descending: true)
+                .limit(10)
+                .get(),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(
+                  child: Padding(
+                    padding: EdgeInsets.all(16.0),
+                    child: CircularProgressIndicator(),
+                  ),
+                );
+              } else if (snapshot.hasError) {
+                return Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Text(
+                      loc.translate('error_loading_quiz_results') ??
+                          'Error loading quiz results',
+                    ),
+                  ),
+                );
+              } else if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+                return Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Text(
+                      loc.translate('no_quiz_results_available') ??
+                          'No quiz results available',
+                    ),
+                  ),
+                );
+              }
+              final docs = snapshot.data!.docs;
+              return Column(
+                children: docs.map((doc) {
+                  final data = doc.data() as Map<String, dynamic>;
+                  final String userId = data['user_id'] ?? '';
+                  final String userName = data['username'] ?? 'Unknown';
+                  final int score = data['score'] as int? ?? 0;
+                  return Card(
+                    margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+                    elevation: 2,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: ListTile(
+                      leading: ProfileAvatar(userId: userId, radius: 25),
+                      title: Text(
+                        userName,
+                        style: const TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 16,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      subtitle: Text(
+                        '${loc.translate('score') ?? 'Score'}: $score',
+                        style: const TextStyle(fontSize: 12, color: Colors.grey),
+                      ),
+                    ),
+                  );
+                }).toList(),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/news_portal/widgets.dart
+++ b/lib/screens/news_portal/widgets.dart
@@ -1,0 +1,67 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import '../../services/localization_service.dart';
+
+/// Common helper widgets and functions for the news portal sections.
+Widget buildSectionHeader(
+    IconData iconData, String title, VoidCallback onTap, {Color? headerColor}) {
+  return ListTile(
+    onTap: onTap,
+    leading: Icon(iconData, size: 28, color: headerColor ?? Colors.blueAccent),
+    title: Text(
+      title,
+      style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+    ),
+    trailing: const Icon(Icons.arrow_forward_ios, size: 16, color: Colors.grey),
+    contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+  );
+}
+
+Widget buildImage(String? imageUrl,
+    {double width = 80, double height = 80, BoxFit fit = BoxFit.cover}) {
+  if (imageUrl != null && imageUrl.isNotEmpty) {
+    if (imageUrl.startsWith('http')) {
+      return CachedNetworkImage(
+        imageUrl: imageUrl,
+        width: width,
+        height: height,
+        fit: fit,
+        placeholder: (context, url) => Container(
+          width: width,
+          height: height,
+          alignment: Alignment.center,
+          child: const CircularProgressIndicator(),
+        ),
+        errorWidget: (context, url, error) => Container(
+          width: width,
+          height: height,
+          color: Colors.grey,
+          child: const Icon(Icons.image, color: Colors.white),
+        ),
+      );
+    } else {
+      return Image.asset(imageUrl, width: width, height: height, fit: fit);
+    }
+  }
+  return Image.asset('assets/images/tenant.png',
+      width: width, height: height, fit: fit);
+}
+
+String formatTimeAgo(DateTime dateTime, LocalizationService loc) {
+  final now = DateTime.now();
+  final diff = now.difference(dateTime);
+  if (diff.inSeconds < 60) {
+    return loc.translate('just_now') ?? 'Just now';
+  }
+  if (diff.inMinutes < 60) {
+    return '${diff.inMinutes} ${loc.translate('minutes_ago') ?? 'minutes ago'}';
+  }
+  if (diff.inHours < 24) {
+    return '${diff.inHours} ${loc.translate('hours_ago') ?? 'hours ago'}';
+  }
+  return '${diff.inDays} ${loc.translate('days_ago') ?? 'days ago'}';
+}
+
+String formatDateTime(DateTime date, String time) {
+  return '${date.day.toString().padLeft(2, '0')}.${date.month.toString().padLeft(2, '0')}.${date.year} $time';
+}

--- a/lib/screens/news_portal_view.dart
+++ b/lib/screens/news_portal_view.dart
@@ -46,7 +46,7 @@ import 'bulletin_board_screen.dart'; // Bulletin – očekuje username, countryI
 // Documents – koristi se u DocumentsScreen
 
 // Dodajemo RideViewModel
-import '../viewmodels/ride_view_model.dart';
+import 'news_portal/news_portal_sections.dart';
 
 // Import DocumentsScreen (sada je navigacija u DocumentsScreen)
 import 'documents_screen.dart';
@@ -393,346 +393,6 @@ class _NewsPortalViewState extends State<NewsPortalView> {
     } catch (error) {
       debugPrint('Error reading construction data: $error');
     }
-  }
-
-  Widget _buildLastPostsSection(LocalizationService loc) {
-    return Card(
-      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      elevation: 3,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-      child: Column(
-        children: [
-          _buildModernSectionHeader(
-              Icons.article, loc.translate('last_posts') ?? "Zadnji postovi",
-              () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (_) => LocalHomeScreen(
-                  username: widget.username,
-                  locationAdmin: widget.locationAdmin,
-                ),
-              ),
-            );
-          }),
-          FutureBuilder<List<Map<String, dynamic>>>(
-            future: _fetchLastPosts(),
-            builder: (context, snapshot) {
-              if (snapshot.connectionState == ConnectionState.waiting) {
-                return const SizedBox(
-                    height: 200,
-                    child: Center(child: CircularProgressIndicator()));
-              } else if (snapshot.hasError) {
-                return SizedBox(
-                    height: 200,
-                    child: Center(
-                        child: Text(loc.translate('error_loading_posts') ??
-                            "Error loading posts")));
-              } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
-                return SizedBox(
-                    height: 200,
-                    child: Center(
-                        child: Text(loc.translate('no_posts_available') ??
-                            "No posts available")));
-              }
-              final posts = snapshot.data!;
-              return Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: GridView.builder(
-                  shrinkWrap: true,
-                  physics: const NeverScrollableScrollPhysics(),
-                  itemCount: posts.length,
-                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 2,
-                    crossAxisSpacing: 8,
-                    mainAxisSpacing: 8,
-                    childAspectRatio: 1,
-                  ),
-                  itemBuilder: (context, index) {
-                    final post = posts[index];
-                    final String imageUrl = post['mediaUrl'] as String? ?? '';
-                    final String title = post['title'] as String? ?? '';
-                    final Timestamp ts = (post['createdAt'] is Timestamp)
-                        ? post['createdAt'] as Timestamp
-                        : Timestamp.now();
-                    final DateTime createdAt = ts.toDate();
-                    final String userName = post['createdBy'] as String? ?? '';
-                    final String userLocation =
-                        post['localNeighborhoodId'] as String? ?? '';
-                    return GestureDetector(
-                      onTap: () {
-                        final postMap = {
-                          'postId': post['postId'],
-                          'userId': post['userId'] ?? '',
-                          'localCountryId': post['localCountryId'] ?? '',
-                          'localCityId': post['localCityId'] ?? '',
-                          'localNeighborhoodId':
-                              post['localNeighborhoodId'] ?? '',
-                          'isVideo': post['isVideo'] ?? false,
-                          'mediaUrl': post['mediaUrl'] ?? '',
-                          'aspectRatio': post['aspectRatio'] ?? 1.0,
-                          'createdAt': post['createdAt'] ?? Timestamp.now(),
-                          'text': post['text'] ?? '',
-                          'views': post['views'] ?? 0,
-                        };
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (_) => PostDetailScreen(post: postMap),
-                          ),
-                        );
-                      },
-                      child: Card(
-                        elevation: 2,
-                        shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(8)),
-                        clipBehavior: Clip.antiAlias,
-                        child: Stack(
-                          children: [
-                            Positioned.fill(
-                                child: _buildImage(imageUrl,
-                                    width: double.infinity,
-                                    height: double.infinity,
-                                    fit: BoxFit.cover)),
-                            Positioned(
-                              bottom: 0,
-                              left: 0,
-                              right: 0,
-                              child: Container(
-                                color: Colors.black.withOpacity(0.5),
-                                padding: const EdgeInsets.all(8.0),
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    if (title.isNotEmpty)
-                                      Text(
-                                        title,
-                                        style: const TextStyle(
-                                            color: Colors.white,
-                                            fontSize: 14,
-                                            fontWeight: FontWeight.bold),
-                                        maxLines: 2,
-                                        overflow: TextOverflow.ellipsis,
-                                      ),
-                                    if (userName.isNotEmpty)
-                                      Padding(
-                                        padding:
-                                            const EdgeInsets.only(top: 4.0),
-                                        child: Text(
-                                          userName,
-                                          style: const TextStyle(
-                                              color: Colors.white70,
-                                              fontSize: 12),
-                                        ),
-                                      ),
-                                    if (userLocation.isNotEmpty)
-                                      Padding(
-                                        padding:
-                                            const EdgeInsets.only(top: 2.0),
-                                        child: Text(
-                                          userLocation,
-                                          style: const TextStyle(
-                                              color: Colors.white70,
-                                              fontSize: 12),
-                                        ),
-                                      ),
-                                    Padding(
-                                      padding: const EdgeInsets.only(top: 2.0),
-                                      child: Text(
-                                        _formatTimeAgo(createdAt, loc),
-                                        style: const TextStyle(
-                                            color: Colors.white60,
-                                            fontSize: 10),
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    );
-                  },
-                ),
-              );
-            },
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildOfficialNoticesSection(LocalizationService loc) {
-    return Card(
-      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      elevation: 3,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-      child: Column(
-        children: [
-          _buildModernSectionHeader(Icons.campaign,
-              loc.translate('official_notices') ?? "Službene obavijesti", () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (_) => BlogScreen(
-                  username: widget.username,
-                  countryId: widget.countryId,
-                  cityId: widget.cityId,
-                  locationId: widget.locationId,
-                ),
-              ),
-            );
-          }),
-          StreamBuilder<QuerySnapshot>(
-            stream: _firestore
-                .collection('countries')
-                .doc(_geoCountry.isNotEmpty ? _geoCountry : widget.countryId)
-                .collection('cities')
-                .doc(_geoCity.isNotEmpty ? _geoCity : widget.cityId)
-                .collection('locations')
-                .doc(_geoNeighborhood.isNotEmpty
-                    ? _geoNeighborhood
-                    : widget.locationId)
-                .collection('blogs')
-                .orderBy('createdAt', descending: true)
-                .limit(2)
-                .snapshots(),
-            builder: (context, snapshot) {
-              if (snapshot.connectionState == ConnectionState.waiting) {
-                return const Center(
-                    child: Padding(
-                        padding: EdgeInsets.all(16.0),
-                        child: CircularProgressIndicator()));
-              }
-              if (snapshot.hasError) {
-                return Center(
-                    child: Padding(
-                        padding: EdgeInsets.all(16.0),
-                        child: Text(loc.translate('error_loading_data') ??
-                            'Error loading data.')));
-              }
-              if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
-                return Center(
-                    child: Padding(
-                        padding: EdgeInsets.all(16.0),
-                        child: Text(loc.translate('no_official_notices') ??
-                            'No official notices available.')));
-              }
-              final docs = snapshot.data!.docs;
-              List<Blog> blogs = docs.map((doc) {
-                return Blog.fromMap(doc.data() as Map<String, dynamic>, doc.id);
-              }).toList();
-              return Column(
-                children: blogs.map((blog) {
-                  final String imageUrl = blog.imageUrls.isNotEmpty
-                      ? blog.imageUrls.first
-                      : 'assets/images/tenant.png';
-                  final Timestamp ts = (blog.createdAt is Timestamp)
-                      ? blog.createdAt as Timestamp
-                      : Timestamp.now();
-                  final DateTime createdAt = ts.toDate();
-                  return GestureDetector(
-                    onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => BlogDetailsScreen(
-                            blog: blog,
-                            username: widget.username,
-                            countryId: widget.countryId,
-                            cityId: widget.cityId,
-                            locationId: widget.locationId,
-                            locationAdmin: widget.locationAdmin,
-                          ),
-                        ),
-                      );
-                    },
-                    child: Card(
-                      margin: const EdgeInsets.symmetric(
-                          horizontal: 8, vertical: 4),
-                      elevation: 2,
-                      shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12)),
-                      clipBehavior: Clip.antiAlias,
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          Stack(
-                            children: [
-                              imageUrl.isNotEmpty
-                                  ? CachedNetworkImage(
-                                      imageUrl: imageUrl,
-                                      width: double.infinity,
-                                      height: 150,
-                                      fit: BoxFit.cover,
-                                      placeholder: (context, url) =>
-                                          const Center(
-                                              child:
-                                                  CircularProgressIndicator()),
-                                      errorWidget: (context, url, error) =>
-                                          Image.asset(
-                                        'assets/images/tenant.png',
-                                        width: double.infinity,
-                                        height: 150,
-                                        fit: BoxFit.cover,
-                                      ),
-                                    )
-                                  : Image.asset(
-                                      'assets/images/tenant.png',
-                                      width: double.infinity,
-                                      height: 150,
-                                      fit: BoxFit.cover,
-                                    ),
-                              Positioned(
-                                bottom: 0,
-                                left: 0,
-                                right: 0,
-                                child: Container(
-                                  color: Colors.black.withOpacity(0.6),
-                                  padding: const EdgeInsets.all(8),
-                                  child: Text(
-                                    blog.title,
-                                    style: const TextStyle(
-                                        color: Colors.white,
-                                        fontSize: 20,
-                                        fontWeight: FontWeight.bold),
-                                  ),
-                                ),
-                              ),
-                            ],
-                          ),
-                          Padding(
-                            padding: const EdgeInsets.all(8.0),
-                            child: Text(
-                              blog.content.length > 100
-                                  ? '${blog.content.substring(0, 100)}...'
-                                  : blog.content,
-                              style: const TextStyle(fontSize: 14),
-                              maxLines: 3,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ),
-                          Padding(
-                            padding:
-                                const EdgeInsets.symmetric(horizontal: 8.0),
-                            child: Text(
-                              _formatTimeAgo(createdAt, loc),
-                              style: const TextStyle(
-                                  fontSize: 10, color: Colors.grey),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  );
-                }).toList(),
-              );
-            },
-          ),
-        ],
-      ),
-    );
   }
 
   Widget _buildMarketplaceSection(LocalizationService loc) {
@@ -1785,23 +1445,96 @@ class _NewsPortalViewState extends State<NewsPortalView> {
             child: Column(
               children: [
                 const SizedBox(height: 8),
-                _buildLastPostsSection(loc),
+                LastPostsSection(
+                  fetchPosts: _fetchLastPosts,
+                  username: widget.username,
+                  locationAdmin: widget.locationAdmin,
+                ),
                 const SizedBox(height: 16),
-                _buildOfficialNoticesSection(loc),
+                OfficialNoticesSection(
+                  username: widget.username,
+                  countryId: widget.countryId,
+                  cityId: widget.cityId,
+                  locationId: widget.locationId,
+                  geoCountry: _geoCountry,
+                  geoCity: _geoCity,
+                  geoNeighborhood: _geoNeighborhood,
+                  locationAdmin: widget.locationAdmin,
+                  firestore: _firestore,
+                ),
                 const SizedBox(height: 16),
-                _buildMarketplaceSection(loc),
+                MarketplaceSection(
+                  fetchAds: _fetchLastMarketplaceAds,
+                  username: widget.username,
+                  countryId: widget.countryId,
+                  cityId: widget.cityId,
+                  locationId: widget.locationId,
+                ),
                 const SizedBox(height: 16),
-                _buildChatRoomSection(loc),
+                ChatRoomSection(
+                  countryId: widget.countryId,
+                  cityId: widget.cityId,
+                  locationId: widget.locationId,
+                  geoCountry: _geoCountry,
+                  geoCity: _geoCity,
+                  geoNeighborhood: _geoNeighborhood,
+                  firestore: _firestore,
+                ),
                 const SizedBox(height: 16),
-                _buildParkingSection(loc),
+                ParkingSection(
+                  parkingPreview: _parkingPreview,
+                  username: widget.username,
+                  countryId: widget.countryId,
+                  cityId: widget.cityId,
+                  locationId: widget.locationId,
+                  locationAdmin: widget.locationAdmin,
+                  formatDateTime: _formatDateTime,
+                ),
                 const SizedBox(height: 16),
-                _buildCommuteSection(loc),
+                CommuteSection(
+                  commutePreview: _commutePreview,
+                  username: widget.username,
+                  countryId: widget.countryId,
+                  cityId: widget.cityId,
+                  locationId: widget.locationId,
+                  auth: _auth,
+                  smallMapControllers: _smallMapControllers,
+                  formatTimeAgo: _formatTimeAgo,
+                ),
                 const SizedBox(height: 16),
-                _buildQuizSection(loc),
+                QuizSection(
+                  username: widget.username,
+                  countryId: widget.countryId,
+                  cityId: widget.cityId,
+                  locationId: widget.locationId,
+                  geoCountry: _geoCountry,
+                  geoCity: _geoCity,
+                  geoNeighborhood: _geoNeighborhood,
+                  firestore: _firestore,
+                ),
                 const SizedBox(height: 16),
-                _buildBulletinBoardSection(loc),
+                BulletinBoardSection(
+                  username: widget.username,
+                  countryId: widget.countryId,
+                  cityId: widget.cityId,
+                  locationId: widget.locationId,
+                  geoCountry: _geoCountry,
+                  geoCity: _geoCity,
+                  geoNeighborhood: _geoNeighborhood,
+                  firestore: _firestore,
+                ),
                 const SizedBox(height: 16),
-                _buildDocumentsSection(loc),
+                DocumentsSection(
+                  username: widget.username,
+                  countryId: widget.countryId,
+                  cityId: widget.cityId,
+                  locationId: widget.locationId,
+                  geoCountry: _geoCountry,
+                  geoCity: _geoCity,
+                  geoNeighborhood: _geoNeighborhood,
+                  firestore: _firestore,
+                  openDocument: _openDocument,
+                ),
                 const SizedBox(height: 16),
                 // Mudra sova – bez navigacije
                 Card(
@@ -1833,7 +1566,13 @@ class _NewsPortalViewState extends State<NewsPortalView> {
                   ),
                 ),
                 const SizedBox(height: 16),
-                _buildBukaSection(loc),
+                BukaSection(
+                  works: _works,
+                  username: widget.username,
+                  countryId: widget.countryId,
+                  cityId: widget.cityId,
+                  locationId: widget.locationId,
+                ),
                 const SizedBox(height: 16),
               ],
             ),


### PR DESCRIPTION
## Summary
- refactor `NewsPortalView` by moving each `_build...Section` method into its own stateless widget
- add shared helpers for section headers and images
- expose section widgets via a new export file
- update `NewsPortalView` to use the new widgets

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d4b8b6548327b6f4293aeb3f58fb