### PR TITLE
Add shimmer skeleton loaders

### DIFF
--- a/lib/screens/news_portal/bulletin_board_section.dart
+++ b/lib/screens/news_portal/bulletin_board_section.dart
@@ -70,11 +70,9 @@ class BulletinBoardSection extends StatelessWidget {
                 .get(),
             builder: (context, snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
-                return const Center(
-                  child: Padding(
-                    padding: EdgeInsets.all(16.0),
-                    child: CircularProgressIndicator(),
-                  ),
+                return Column(
+                  children:
+                      List.generate(2, (_) => buildListTileSkeleton()),
                 );
               } else if (snapshot.hasError) {
                 return Center(

--- a/lib/screens/news_portal/chat_room_section.dart
+++ b/lib/screens/news_portal/chat_room_section.dart
@@ -67,11 +67,9 @@ class ChatRoomSection extends StatelessWidget {
                 .get(),
             builder: (context, snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
-                return const Center(
-                  child: Padding(
-                    padding: EdgeInsets.all(16.0),
-                    child: CircularProgressIndicator(),
-                  ),
+                return Column(
+                  children:
+                      List.generate(3, (_) => buildChatMessageSkeleton()),
                 );
               } else if (snapshot.hasError) {
                 return Center(

--- a/lib/screens/news_portal/documents_section.dart
+++ b/lib/screens/news_portal/documents_section.dart
@@ -73,11 +73,9 @@ class DocumentsSection extends StatelessWidget {
                 .get(),
             builder: (context, snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
-                return const Center(
-                  child: Padding(
-                    padding: EdgeInsets.all(16.0),
-                    child: CircularProgressIndicator(),
-                  ),
+                return Column(
+                  children:
+                      List.generate(2, (_) => buildListTileSkeleton()),
                 );
               } else if (snapshot.hasError) {
                 return Center(

--- a/lib/screens/news_portal/last_posts_section.dart
+++ b/lib/screens/news_portal/last_posts_section.dart
@@ -47,9 +47,9 @@ class LastPostsSection extends StatelessWidget {
             future: fetchPosts(),
             builder: (context, snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
-                return const SizedBox(
+                return SizedBox(
                   height: 200,
-                  child: Center(child: CircularProgressIndicator()),
+                  child: buildPostsGridSkeleton(),
                 );
               } else if (snapshot.hasError) {
                 return SizedBox(

--- a/lib/screens/news_portal/marketplace_section.dart
+++ b/lib/screens/news_portal/marketplace_section.dart
@@ -53,8 +53,9 @@ class MarketplaceSection extends StatelessWidget {
             future: fetchAds(),
             builder: (context, snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
-                return const Center(
-                  child: SizedBox(height: 100, child: CircularProgressIndicator()),
+                return Column(
+                  children:
+                      List.generate(2, (_) => buildMarketplaceAdSkeleton()),
                 );
               } else if (snapshot.hasError) {
                 return Center(

--- a/lib/screens/news_portal/official_notices_section.dart
+++ b/lib/screens/news_portal/official_notices_section.dart
@@ -73,11 +73,9 @@ class OfficialNoticesSection extends StatelessWidget {
                 .snapshots(),
             builder: (context, snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
-                return const Center(
-                  child: Padding(
-                    padding: EdgeInsets.all(16.0),
-                    child: CircularProgressIndicator(),
-                  ),
+                return Column(
+                  children:
+                      List.generate(2, (_) => buildBlogPostSkeleton()),
                 );
               }
               if (snapshot.hasError) {

--- a/lib/screens/news_portal/quiz_section.dart
+++ b/lib/screens/news_portal/quiz_section.dart
@@ -74,11 +74,9 @@ class QuizSection extends StatelessWidget {
                 .get(),
             builder: (context, snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
-                return const Center(
-                  child: Padding(
-                    padding: EdgeInsets.all(16.0),
-                    child: CircularProgressIndicator(),
-                  ),
+                return Column(
+                  children:
+                      List.generate(3, (_) => buildQuizResultSkeleton()),
                 );
               } else if (snapshot.hasError) {
                 return Center(

--- a/lib/screens/news_portal/widgets.dart
+++ b/lib/screens/news_portal/widgets.dart
@@ -1,5 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
 import '../../services/localization_service.dart';
 
 /// Common helper widgets and functions for the news portal sections.
@@ -64,4 +65,175 @@ String formatTimeAgo(DateTime dateTime, LocalizationService loc) {
 
 String formatDateTime(DateTime date, String time) {
   return '${date.day.toString().padLeft(2, '0')}.${date.month.toString().padLeft(2, '0')}.${date.year} $time';
+}
+
+/// Generic shimmer wrapper used for skeleton placeholders.
+Widget buildShimmer(Widget child) {
+  return Shimmer.fromColors(
+    baseColor: Colors.grey.shade300,
+    highlightColor: Colors.grey.shade100,
+    child: child,
+  );
+}
+
+/// Skeleton for a simple list tile card (bulletins, documents).
+Widget buildListTileSkeleton() {
+  return buildShimmer(
+    Card(
+      margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+      child: ListTile(
+        leading: Container(width: 48, height: 48, color: Colors.grey[300]),
+        title: Container(height: 16, color: Colors.grey[300]),
+        subtitle: Container(
+          margin: const EdgeInsets.only(top: 8),
+          height: 12,
+          width: 100,
+          color: Colors.grey[300],
+        ),
+      ),
+    ),
+  );
+}
+
+/// Skeleton for chat message preview.
+Widget buildChatMessageSkeleton() {
+  return buildShimmer(
+    Card(
+      margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              width: 40,
+              height: 40,
+              decoration: const BoxDecoration(
+                color: Colors.grey,
+                shape: BoxShape.circle,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(height: 14, width: 100, color: Colors.grey[300]),
+                  const SizedBox(height: 8),
+                  Container(height: 14, color: Colors.grey[300]),
+                  const SizedBox(height: 4),
+                  Container(height: 12, width: 80, color: Colors.grey[300]),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+/// Skeleton for marketplace ads.
+Widget buildMarketplaceAdSkeleton() {
+  return buildShimmer(
+    Card(
+      margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+      child: Row(
+        children: [
+          Container(width: 100, height: 100, color: Colors.grey[300]),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(height: 16, color: Colors.grey[300]),
+                  const SizedBox(height: 8),
+                  Container(height: 14, color: Colors.grey[300]),
+                  const SizedBox(height: 8),
+                  Container(height: 12, width: 80, color: Colors.grey[300]),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+/// Skeleton for blog/notice cards.
+Widget buildBlogPostSkeleton() {
+  return buildShimmer(
+    Card(
+      margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Container(height: 150, color: Colors.grey[300]),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(height: 16, color: Colors.grey[300]),
+                const SizedBox(height: 8),
+                Container(height: 14, color: Colors.grey[300]),
+                const SizedBox(height: 4),
+                Container(height: 12, width: 80, color: Colors.grey[300]),
+              ],
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+/// Skeleton for quiz leaderboard entries.
+Widget buildQuizResultSkeleton() {
+  return buildShimmer(
+    Card(
+      margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+      child: ListTile(
+        leading: Container(
+          width: 50,
+          height: 50,
+          decoration: const BoxDecoration(
+            shape: BoxShape.circle,
+            color: Colors.grey,
+          ),
+        ),
+        title: Container(height: 16, color: Colors.grey[300]),
+        subtitle: Container(
+          margin: const EdgeInsets.only(top: 8),
+          height: 12,
+          width: 80,
+          color: Colors.grey[300],
+        ),
+      ),
+    ),
+  );
+}
+
+/// Grid skeleton for the latest posts preview.
+Widget buildPostsGridSkeleton() {
+  return GridView.builder(
+    shrinkWrap: true,
+    physics: const NeverScrollableScrollPhysics(),
+    itemCount: 4,
+    gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+      crossAxisCount: 2,
+      crossAxisSpacing: 8,
+      mainAxisSpacing: 8,
+      childAspectRatio: 1,
+    ),
+    itemBuilder: (context, index) => buildShimmer(
+      Card(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        child: Container(color: Colors.grey[300]),
+      ),
+    ),
+  );
 }


### PR DESCRIPTION
## Summary
- add shimmer utilities for list and grid placeholders
- render skeleton loaders while news portal sections load

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d9522bf883279cb68e763462ade9