### PR TITLE
Refactor commute preview card and map handling

### DIFF
--- a/lib/commute_screens/commute_ride_detail_screen.dart
+++ b/lib/commute_screens/commute_ride_detail_screen.dart
@@ -224,23 +224,30 @@ class _CommuteRideDetailScreenState extends State<CommuteRideDetailScreen> {
             flex: 2,
             child: Stack(
               children: [
-                GoogleMap(
-                  onMapCreated: (controller) {
-                    _mapController = controller;
-                    if (_initialBounds != null) {
-                      _mapController?.moveCamera(
-                        CameraUpdate.newLatLngBounds(_initialBounds!, 60),
-                      );
-                    }
+                GestureDetector(
+                  onTap: () {
+                    setState(() {
+                      _isFullScreen = true;
+                    });
                   },
-                  markers: _markers.union(_exitMarkers),
-                  polylines: _polylines,
-                  initialCameraPosition: const CameraPosition(
-                    target: LatLng(45.8150, 15.9819),
-                    zoom: 6,
+                  child: GoogleMap(
+                    onMapCreated: (controller) {
+                      _mapController = controller;
+                      if (_initialBounds != null) {
+                        _mapController?.moveCamera(
+                          CameraUpdate.newLatLngBounds(_initialBounds!, 60),
+                        );
+                      }
+                    },
+                    markers: _markers.union(_exitMarkers),
+                    polylines: _polylines,
+                    initialCameraPosition: const CameraPosition(
+                      target: LatLng(45.8150, 15.9819),
+                      zoom: 6,
+                    ),
+                    myLocationEnabled: false,
+                    myLocationButtonEnabled: false,
                   ),
-                  myLocationEnabled: false,
-                  myLocationButtonEnabled: false,
                 ),
               ],
             ),

--- a/lib/commute_widgets/commute_preview_card.dart
+++ b/lib/commute_widgets/commute_preview_card.dart
@@ -1,0 +1,92 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+
+import '../commute_screens/commute_ride_detail_screen.dart';
+import '../models/ride_model.dart';
+import '../services/localization_service.dart';
+import '../services/location_service.dart';
+
+class CommutePreviewCard extends StatelessWidget {
+  final Ride ride;
+  final LocalizationService loc;
+  final String Function(DateTime, LocalizationService) formatTimeAgo;
+
+  const CommutePreviewCard({
+    super.key,
+    required this.ride,
+    required this.loc,
+    required this.formatTimeAgo,
+  });
+
+  String _buildStaticMapUrl() {
+    final apiKey = LocationService().apiKey;
+    final start = '${ride.startLocation.latitude},${ride.startLocation.longitude}';
+    final end = '${ride.endLocation.latitude},${ride.endLocation.longitude}';
+    final buffer = StringBuffer(start);
+    for (final gp in ride.route) {
+      buffer.write('|${gp.latitude},${gp.longitude}');
+    }
+    buffer.write('|$end');
+    final path = buffer.toString();
+    return 'https://maps.googleapis.com/maps/api/staticmap'
+        '?size=600x300&markers=color:green|$start&markers=color:red|$end'
+        '&path=color:0x0000ff|weight:4|$path&key=$apiKey';
+  }
+
+  void _openDetail(BuildContext context) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => CommuteRideDetailScreen(
+          rideId: ride.rideId,
+          userId: FirebaseAuth.instance.currentUser?.uid ?? '',
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final createdAt = ride.createdAt.toDate();
+    final mapUrl = _buildStaticMapUrl();
+
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '${loc.translate('driver') ?? 'Driver'}: ${ride.driverName}',
+              style: const TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 4),
+            Text('${loc.translate('start_address') ?? 'Polazište'}: ${ride.startAddress}'),
+            Text('${loc.translate('destination') ?? 'Odredište'}: ${ride.endAddress}'),
+            const SizedBox(height: 4),
+            Text(
+              '${loc.translate('published') ?? 'Objavljeno'}: ${formatTimeAgo(createdAt, loc)}',
+              style: const TextStyle(fontSize: 12, color: Colors.grey),
+            ),
+            const SizedBox(height: 8),
+            GestureDetector(
+              onTap: () => _openDetail(context),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(4),
+                child: Image.network(
+                  mapUrl,
+                  height: 120,
+                  width: double.infinity,
+                  fit: BoxFit.cover,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/news_portal/commute_section.dart
+++ b/lib/screens/news_portal/commute_section.dart
@@ -1,8 +1,6 @@
-import 'dart:async';
 
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:provider/provider.dart';
 
 import '../../models/ride_model.dart';
@@ -10,6 +8,7 @@ import '../../services/localization_service.dart';
 import '../commute_screens/commute_ride_detail_screen.dart';
 import '../commute_screens/commute_rides_list_screen.dart';
 import 'widgets.dart';
+import '../../commute_widgets/commute_preview_card.dart';
 
 class CommuteSection extends StatelessWidget {
   final List<Ride> commutePreview;
@@ -18,7 +17,6 @@ class CommuteSection extends StatelessWidget {
   final String cityId;
   final String locationId;
   final FirebaseAuth? auth;
-  final Map<String, Completer<GoogleMapController>> smallMapControllers;
   final String Function(DateTime, LocalizationService) formatTimeAgo;
 
   const CommuteSection({
@@ -29,7 +27,6 @@ class CommuteSection extends StatelessWidget {
     required this.cityId,
     required this.locationId,
     required this.auth,
-    required this.smallMapControllers,
     required this.formatTimeAgo,
   });
 
@@ -81,11 +78,10 @@ class CommuteSection extends StatelessWidget {
                               ),
                             );
                           },
-                          child: _CommutePreviewCard(
+                          child: CommutePreviewCard(
                             ride: ride,
                             loc: loc,
                             formatTimeAgo: formatTimeAgo,
-                            mapControllers: smallMapControllers,
                           ),
                         ),
                       )
@@ -97,131 +93,3 @@ class CommuteSection extends StatelessWidget {
   }
 }
 
-class _CommutePreviewCard extends StatelessWidget {
-  final Ride ride;
-  final LocalizationService loc;
-  final String Function(DateTime, LocalizationService) formatTimeAgo;
-  final Map<String, Completer<GoogleMapController>> mapControllers;
-
-  const _CommutePreviewCard({
-    required this.ride,
-    required this.loc,
-    required this.formatTimeAgo,
-    required this.mapControllers,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final String driverName = ride.driverName;
-    final DateTime createdAt = ride.createdAt.toDate();
-    final double startLat = ride.startLocation.latitude;
-    final double startLng = ride.startLocation.longitude;
-    final double endLat = ride.endLocation.latitude;
-    final double endLng = ride.endLocation.longitude;
-    final String rideId = ride.rideId;
-
-    List<LatLng> routeLatLng = [];
-    for (var gp in ride.route) {
-      routeLatLng.add(LatLng(gp.latitude, gp.longitude));
-    }
-    mapControllers.putIfAbsent(rideId, () => Completer<GoogleMapController>());
-
-    final startMarker = Marker(
-      markerId: MarkerId('start_$rideId'),
-      position: LatLng(startLat, startLng),
-      icon: BitmapDescriptor.defaultMarkerWithHue(BitmapDescriptor.hueGreen),
-    );
-    final endMarker = Marker(
-      markerId: MarkerId('end_$rideId'),
-      position: LatLng(endLat, endLng),
-      icon: BitmapDescriptor.defaultMarkerWithHue(BitmapDescriptor.hueRed),
-    );
-    final markers = {startMarker, endMarker};
-
-    final Set<Polyline> polylines = {};
-    if (routeLatLng.isNotEmpty) {
-      polylines.add(
-        Polyline(
-          polylineId: PolylineId('ride_$rideId'),
-          color: Colors.blue,
-          width: 4,
-          points: routeLatLng,
-        ),
-      );
-    }
-
-    final List<LatLng> latLngList = [
-      LatLng(startLat, startLng),
-      LatLng(endLat, endLng),
-      ...routeLatLng
-    ];
-    LatLngBounds? bounds;
-    if (latLngList.isNotEmpty) {
-      double minLat = latLngList.first.latitude;
-      double maxLat = latLngList.first.latitude;
-      double minLng = latLngList.first.longitude;
-      double maxLng = latLngList.first.longitude;
-      for (var ll in latLngList) {
-        if (ll.latitude < minLat) minLat = ll.latitude;
-        if (ll.latitude > maxLat) maxLat = ll.latitude;
-        if (ll.longitude < minLng) minLng = ll.longitude;
-        if (ll.longitude > maxLng) maxLng = ll.longitude;
-      }
-      bounds = LatLngBounds(
-        southwest: LatLng(minLat, minLng),
-        northeast: LatLng(maxLat, maxLng),
-      );
-    }
-
-    return Card(
-      margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
-      elevation: 2,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-      child: Padding(
-        padding: const EdgeInsets.all(8),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              '${loc.translate('driver') ?? 'Driver'}: $driverName',
-              style: const TextStyle(fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 4),
-            Text('${loc.translate('start_address') ?? 'Polazište'}: ${ride.startAddress}'),
-            Text('${loc.translate('destination') ?? 'Odredište'}: ${ride.endAddress}'),
-            const SizedBox(height: 4),
-            Text(
-              '${loc.translate('published') ?? 'Objavljeno'}: ${formatTimeAgo(createdAt, loc)}',
-              style: const TextStyle(fontSize: 12, color: Colors.grey),
-            ),
-            const SizedBox(height: 8),
-            SizedBox(
-              height: 120,
-              child: GoogleMap(
-                onMapCreated: (controller) async {
-                  if (!mapControllers[rideId]!.isCompleted) {
-                    mapControllers[rideId]!.complete(controller);
-                  }
-                  if (bounds != null) {
-                    await Future.delayed(const Duration(milliseconds: 300));
-                    controller.animateCamera(
-                      CameraUpdate.newLatLngBounds(bounds, 50),
-                    );
-                  }
-                },
-                markers: markers,
-                polylines: polylines,
-                initialCameraPosition: CameraPosition(
-                  target: LatLng(startLat, startLng),
-                  zoom: 4.5,
-                ),
-                zoomControlsEnabled: false,
-                myLocationEnabled: false,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}


### PR DESCRIPTION
## Summary
- move commute preview card into its own widget file
- display a static map image for ride previews
- allow tapping map in details screen to expand to full screen
- remove unused GoogleMap controllers and widget code

## Testing
- `dart format lib` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840dc54413883278b768fd9e9097653