### PR TITLE
Fix import paths and duplicate class name conflicts

### DIFF
--- a/lib/screens/news_portal/commute_section.dart
+++ b/lib/screens/news_portal/commute_section.dart
@@ -5,8 +5,8 @@ import 'package:provider/provider.dart';
 
 import '../../models/ride_model.dart';
 import '../../services/localization_service.dart';
-import '../commute_screens/commute_ride_detail_screen.dart';
-import '../commute_screens/commute_rides_list_screen.dart';
+import '../../commute_screens/commute_ride_detail_screen.dart';
+import '../../commute_screens/commute_rides_list_screen.dart';
 import 'widgets.dart';
 import '../../commute_widgets/commute_preview_card.dart';
 

--- a/lib/screens/news_portal/last_posts_section.dart
+++ b/lib/screens/news_portal/last_posts_section.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../services/localization_service.dart';
-import '../local/screens/local_home_screen.dart';
-import '../local/screens/post_detail_screen.dart';
+import '../../local/screens/local_home_screen.dart';
+import '../../local/screens/post_detail_screen.dart';
 import 'widgets.dart';
 
 class LastPostsSection extends StatelessWidget {

--- a/lib/screens/news_portal/quiz_section.dart
+++ b/lib/screens/news_portal/quiz_section.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../services/localization_service.dart';
-import '../games_screen.dart';
+import '../games_screen.dart' show GamesScreen;
 import 'widgets.dart';
 import '../news_portal_view.dart' show ProfileAvatar; // to use ProfileAvatar class defined there
 


### PR DESCRIPTION
## Summary
- fix incorrect relative imports for local home and post detail screens
- correct commute section imports for commute screens
- restrict import from games screen to avoid duplicate ProfileAvatar class

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e6b610948327ba8c35a22bc65d7e